### PR TITLE
Fix Docker image tags to use consistent 10-character git SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/skeletos
           tags: |
-            type=sha,prefix=git-
+            type=raw,value=git-${{ steps.commit.outputs.sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
Replace Docker metadata action's default SHA format with custom 10-character SHA from git rev-parse to ensure consistent tag naming.