### PR TITLE
Set up Husky pre-commit hooks with lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm exec lint-staged

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to help you get started quickly and maintain code quality.
   - [Prettier](#prettier)
   - [Vitest](#vitest)
   - [Docker](#docker)
+  - [Pre-commit Hooks](#pre-commit-hooks)
 - [Usage](#usage)
 - [License](#license)
 
@@ -26,6 +27,7 @@ to help you get started quickly and maintain code quality.
 - Prettier for code formatting
 - Vitest for testing
 - Docker for containerization
+- Husky with lint-staged for pre-commit hooks
 
 ## Prerequisites
 
@@ -91,6 +93,20 @@ Vitest is configured in `vitest.config.ts`. It is set up for testing TypeScript 
 ### Docker
 
 The project includes a `Dockerfile` for containerization. This allows you to build and run your application in a Docker container.
+
+### Pre-commit Hooks
+
+The project uses Husky with lint-staged to automatically format code before commits. The pre-commit hook runs Prettier on staged files to ensure consistent code formatting.
+
+To set up pre-commit hooks (if not already configured):
+
+```bash
+npx husky init
+echo "pnpm exec lint-staged" > .husky/pre-commit
+chmod +x .husky/pre-commit
+```
+
+The lint-staged configuration in `package.json` formats TypeScript, JavaScript, Markdown, and YAML files automatically on commit.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:fix": "pnpm run lint:base src -- --fix",
     "lint:base": "eslint -c eslint.config.js --max-warnings 0",
     "lint:circular": "madge --circular --extensions ts src",
-    "prettier:check": "prettier --check ."
+    "prettier:check": "prettier --check .",
+    "prepare": "husky || true"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
**Summary:**
- Initialize Husky v9+ with modern npx husky init command
- Add pre-commit hook to run lint-staged for automatic code formatting
- Update prepare script to handle production builds gracefully
- Add pre-commit hooks documentation to README